### PR TITLE
add BPG support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -507,6 +507,9 @@ AC_ARG_WITH(libtiff,
 AC_ARG_WITH(libjasper,
             [AC_HELP_STRING([--with-libjasper],
                             [enable JPEG2000 loader for gdk-pixbuf])])
+AC_ARG_WITH(libbpg,
+            [AC_HELP_STRING([--with-libbpg],
+                            [enable BPG loader for gdk-pixbuf])])
 AC_ARG_WITH(gdiplus,
             [AC_HELP_STRING([--without-gdiplus],
                             [disable GDI+ loaders for gdk-pixbuf on Windows])])
@@ -635,10 +638,22 @@ dnl Test for libjasper
 *** --without-libjasper to configure])
   fi
 
+dnl Test for libbpg
+  if test x$with_libbpg = xyes && test -z "$LIBBPG"; then
+    AC_CHECK_LIB(bpg, bpg_decoder_open, LIBBPG=-lbpg, [], -lm)
+  fi
+
+  if test x$with_libbpg = xyes && test -z "$LIBBPG"; then
+     AC_MSG_ERROR([
+*** Checks for BPG loader failed. You can build without it by passing
+*** --without-libbpg to configure])
+  fi
+
 AC_SUBST(LIBTIFF)
 AC_SUBST(LIBJPEG)
 AC_SUBST(LIBPNG)
 AC_SUBST(LIBJASPER)
+AC_SUBST(LIBBPG)
 
 AM_CONDITIONAL(BUILD_DYNAMIC_MODULES, $dynworks)
 
@@ -671,6 +686,9 @@ fi
 all_loaders="ani,icns,tga,png,pnm,xbm,xpm,qtif"
 if test x$with_libjasper = xyes; then
   all_loaders="$all_loaders,jasper"
+fi
+if test x$with_libbpg = xyes; then
+  all_loaders="$all_loaders,bpg"
 fi
 if test x$os_win32 = xyes && test x$with_gdiplus != xno; then
   # Skip PNG, see comment above
@@ -736,6 +754,7 @@ AM_CONDITIONAL(INCLUDE_XBM, [test x"$INCLUDE_xbm" = xyes])
 AM_CONDITIONAL(INCLUDE_TGA, [test x"$INCLUDE_tga" = xyes])
 AM_CONDITIONAL(INCLUDE_ICNS, [test x"$INCLUDE_icns" = xyes])
 AM_CONDITIONAL(INCLUDE_JASPER, [test x"$INCLUDE_jasper" = xyes])
+AM_CONDITIONAL(INCLUDE_BPG, [test x"$INCLUDE_bpg" = xyes])
 AM_CONDITIONAL(INCLUDE_QTIF, [test x"$INCLUDE_qtif" = xyes])
 # As all GDI+ loaders are either built-in or not, arbitrarily just
 # check one of the variables here
@@ -796,6 +815,7 @@ AM_CONDITIONAL(HAVE_TIFF, test "x$LIBTIFF" != x)
 AM_CONDITIONAL(HAVE_PNG, test "x$LIBPNG" != x)
 AM_CONDITIONAL(HAVE_JPEG, test "x$LIBJPEG" != x)
 AM_CONDITIONAL(HAVE_JASPER, test "x$LIBJASPER" != x)
+AM_CONDITIONAL(HAVE_BPG, test "x$LIBBPG" != x)
 
 if $dynworks ; then
   STATIC_LIB_DEPS=
@@ -813,8 +833,11 @@ if $dynworks ; then
   if echo "$included_loaders" | egrep '(^|,)jasper($|,)' > /dev/null; then
     STATIC_LIB_DEPS="$STATIC_LIB_DEPS $LIBJASPER"
   fi
+  if echo "$included_loaders" | egrep '(^|,)bpg($|,)' > /dev/null; then
+    STATIC_LIB_DEPS="$STATIC_LIB_DEPS $LIBBPG"
+  fi
 else
-  STATIC_LIB_DEPS="$LIBTIFF $LIBJPEG $LIBPNG $LIBJASPER"
+  STATIC_LIB_DEPS="$LIBTIFF $LIBJPEG $LIBPNG $LIBJASPER $LIBBPG"
 fi
 
 # Checks to see whether we should include mediaLib

--- a/gdk-pixbuf/Makefile.am
+++ b/gdk-pixbuf/Makefile.am
@@ -171,6 +171,14 @@ libpixbufloader_jasper_la_LDFLAGS = -avoid-version -module $(no_undefined)
 libpixbufloader_jasper_la_LIBADD = $(LIBJASPER) $(module_libs)
 
 #
+# The BPG loader
+#
+libstatic_pixbufloader_bpg_la_SOURCES = io-bpg.c
+libpixbufloader_bpg_la_SOURCES = io-bpg.c
+libpixbufloader_bpg_la_LDFLAGS = -avoid-version -module $(no_undefined)
+libpixbufloader_bpg_la_LIBADD = $(LIBBPG) $(module_libs)
+
+#
 # The QTIF loader
 #
 libstatic_pixbufloader_qtif_la_SOURCES = io-qtif.c
@@ -413,6 +421,14 @@ JASPER_LIB = libpixbufloader-jasper.la
 endif
 endif
 
+if HAVE_BPG
+if INCLUDE_BPG
+STATIC_BPG_LIB = libstatic-pixbufloader-bpg.la
+else
+BPG_LIB = libpixbufloader-bpg.la
+endif
+endif
+
 if INCLUDE_QTIF
 STATIC_QTIF_LIB = libstatic-pixbufloader-qtif.la
 else
@@ -438,6 +454,7 @@ loader_LTLIBRARIES = 	\
 	$(TGA_LIB)	\
 	$(ICNS_LIB)	\
 	$(JASPER_LIB)	\
+	$(BPG_LIB)	\
 	$(QTIF_LIB)	\
 	$(GDIPLUS_LIBS)
 
@@ -459,6 +476,7 @@ noinst_LTLIBRARIES =		\
 	$(STATIC_TGA_LIB)	\
 	$(STATIC_ICNS_LIB)	\
 	$(STATIC_JASPER_LIB)	\
+	$(STATIC_BPG_LIB)	\
 	$(STATIC_QTIF_LIB)	\
 	$(STATIC_GDIPLUS_LIBS)
 

--- a/gdk-pixbuf/gdk-pixbuf-io.c
+++ b/gdk-pixbuf/gdk-pixbuf-io.c
@@ -466,6 +466,9 @@ gdk_pixbuf_io_init (void)
 #ifdef INCLUDE_jasper
         load_one_builtin_module (jasper);
 #endif
+#ifdef INCLUDE_bpg
+        load_one_builtin_module (bpg);
+#endif
 #ifdef INCLUDE_qtif
         load_one_builtin_module (qtif);
 #endif
@@ -664,6 +667,7 @@ module (xbm);
 module (tga);
 module (icns);
 module (jasper);
+module (bpg);
 module (qtif);
 module (gdip_ico);
 module (gdip_wmf);
@@ -748,6 +752,9 @@ gdk_pixbuf_load_module_unlocked (GdkPixbufModule *image_module,
 #endif
 #ifdef INCLUDE_jasper
         try_module (jasper,jasper);
+#endif
+#ifdef INCLUDE_bpg
+        try_module (bpg,bpg);
 #endif
 #ifdef INCLUDE_qtif
         try_module (qtif,qtif);

--- a/gdk-pixbuf/io-bpg.c
+++ b/gdk-pixbuf/io-bpg.c
@@ -1,0 +1,143 @@
+/* BPG loader
+ *
+ * Copyright (c) 2016 Valérian Rousset <valerian.rousset@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "gdk-pixbuf-private.h"
+
+#include <stdint.h>
+#include <libbpg.h>
+
+G_MODULE_EXPORT void fill_vtable(GdkPixbufModule * module);
+G_MODULE_EXPORT void fill_info(GdkPixbufFormat * info);
+
+static GdkPixbuf *get_pixbuf(BPGDecoderContext * img, GError ** error)
+{
+	BPGImageInfo img_info;
+
+	bpg_decoder_get_info(img, &img_info);
+	size_t width = img_info.width;
+	size_t height = img_info.height;
+
+	BPGDecoderOutputFormat out_format;
+	size_t real_bit_depth;
+	switch (img_info.bit_depth) {
+	case 8:
+		if (img_info.has_alpha) {
+			out_format = BPG_OUTPUT_FORMAT_RGBA32;
+			real_bit_depth = 32;
+		} else {
+			out_format = BPG_OUTPUT_FORMAT_RGB24;
+			real_bit_depth = 24;
+		}
+		break;
+	default:
+		g_set_error(error,
+			    GDK_PIXBUF_ERROR,
+			    GDK_PIXBUF_ERROR_FAILED, _("Invalid bit_depth"));
+
+		return NULL;
+	}
+
+	size_t line_size = real_bit_depth / 8;
+
+	GdkPixbuf *pixbuf = gdk_pixbuf_new(GDK_COLORSPACE_RGB,
+					   img_info.has_alpha,
+					   8,
+					   width,
+					   height);
+	guchar *pixels = gdk_pixbuf_get_pixels(pixbuf);
+
+	bpg_decoder_start(img, out_format);
+	for (size_t y = 0; y < height; ++y) {
+		guchar *pixel_dest = pixels + (width * y * line_size);
+		bpg_decoder_get_line(img, pixel_dest);
+	}
+
+	return pixbuf;
+}
+
+static GdkPixbuf *bpg_image_load(FILE * file, GError ** error)
+{
+	fseek(file, 0, SEEK_END);
+	size_t file_size = ftell(file);
+	fseek(file, 0, SEEK_SET);
+
+	uint8_t *file_content = calloc(file_size, sizeof(*file_content));
+	if (fread(file_content, 1, file_size, file) != file_size) {
+		g_set_error(error,
+			    GDK_PIXBUF_ERROR,
+			    GDK_PIXBUF_ERROR_FAILED, _("Filed changed size"));
+		free(file_content);
+		return NULL;
+	}
+
+	BPGDecoderContext *img = bpg_decoder_open();
+	if (bpg_decoder_decode(img, file_content, file_size) < 0) {
+		g_set_error(error,
+			    GDK_PIXBUF_ERROR,
+			    GDK_PIXBUF_ERROR_FAILED,
+			    _("Unable to decode image"));
+		bpg_decoder_close(img);
+		free(file_content);
+		return NULL;
+	}
+	free(file_content);
+
+	GdkPixbuf *pixbuf = get_pixbuf(img, error);
+
+	bpg_decoder_close(img);
+
+	return pixbuf;
+}
+
+#ifndef INCLUDE_bpg
+#define MODULE_ENTRY(function) G_MODULE_EXPORT void function
+#else
+#define MODULE_ENTRY(function) void _gdk_pixbuf__bpg_ ## function
+#endif
+
+MODULE_ENTRY(fill_vtable) (GdkPixbufModule * module) {
+	module->load = bpg_image_load;
+}
+
+MODULE_ENTRY(fill_info) (GdkPixbufFormat * info) {
+	static const GdkPixbufModulePattern signature[] = {
+		{"\x42\x50\x47\xfb", NULL, 100},
+		{NULL, NULL, 0}
+	};
+	static const gchar *mime_types[] = {
+		"application/octet-stream",
+		NULL
+	};
+	static const gchar *extensions[] = {
+		"bpg",
+		NULL
+	};
+
+	info->name = "bpg";
+	info->signature = (GdkPixbufModulePattern *) signature;
+	info->description = NC_("image format", "Better Portable Graphics");
+	info->mime_types = (gchar **) mime_types;
+	info->extensions = (gchar **) extensions;
+	info->flags = GDK_PIXBUF_FORMAT_THREADSAFE;
+	info->license = "LGPL";
+	info->disabled = FALSE;
+}


### PR DESCRIPTION
so, [BPG](http://bellard.org/bpg/) is a new image format, which better compression ratio and quality than JPEG, there is also support for alpha and animations.

this PR add support for it, as it is not well spread for a library, you can install instruction for `libbpg` in the [README](https://github.com/mirrorer/libbpg/blob/master/README). I used it as a shared library, which was not the case of the default `Makefile`, you may want to apply this [patch](https://github.com/tharvik/overlay/blob/master/media-libs/libbpg/files/libbpg-0.9.6-shared-lib.patch) (and if you happend to have a Gentoo, it is added to my [overlay](https://github.com/tharvik/overlay)).

with this, I was able to `load` the most common images, if the need arise to have more support (like animation or weird bit depth), I can take care of it.
