### PR TITLE
using #!/usr/bin/env bash instead of #!/usr/bin/bash

### DIFF
--- a/build-aux/post-install.sh
+++ b/build-aux/post-install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 libdir="$1"
 binary_version="$2"


### PR DESCRIPTION
Building failed on ubuntu 18.04 using jhbuild. 
Couldn't find /usr/bin/bash, as bash resides in /bin for my installation.